### PR TITLE
Use require() instead of requireCordovaModule() to load 'xcode'

### DIFF
--- a/hooks/lib/ios/xcodePreferences.js
+++ b/hooks/lib/ios/xcodePreferences.js
@@ -59,7 +59,7 @@ function enableAssociativeDomainsCapability(context) {
  * - add .entitlements file to Code Sign Entitlements preference.
  */
 function activateAssociativeDomains(context, projFolder) {
-    var xcode = context.requireCordovaModule('xcode');
+    var xcode = require('xcode');
 
     var projectPath = path.join(projFolder, 'project.pbxproj');
     var pbxProject;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "xml2js": ">=0.4",
     "rimraf": ">=2.4",
     "node-version-compare": ">=1.0.1",
-    "plist": ">=1.2.0"
+    "plist": ">=1.2.0",
+    "xcode": ">=2.0.0"
   },
   "author": "Nikolay Demyankov for Nordnet Bank AB",
   "license": "MIT",


### PR DESCRIPTION
Cordova 9 no longer allows loading non-cordova modules with requireCordovaModule().